### PR TITLE
fix(consumer): incremental auth consumer index

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -23,6 +23,7 @@ local _M = {
     enable_admin = true,
     enable_dev_mode = false,
     enable_reuseport = true,
+    enable_incremental_consumer_index = false,
     show_upstream_status_in_response_header = false,
     enable_ipv6 = true,
     enable_http2 = true,

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -204,6 +204,10 @@ local config_schema = {
                     type = "boolean",
                     default = true
                 },
+                enable_incremental_consumer_index = {
+                    type = "boolean",
+                    default = false,
+                },
                 ssl = {
                     type = "object",
                     properties = {

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -25,6 +25,7 @@ local ipairs         = ipairs
 local pairs          = pairs
 local next           = next
 local type           = type
+local tostring       = tostring
 local string_sub     = string.sub
 local string_find    = string.find
 local consumers

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -341,8 +341,8 @@ local function sync_lookup_maps(index, old_consumer, new_consumer)
     local etcd_key = old_consumer and old_consumer._etcd_key or new_consumer._etcd_key
 
     for key_attr, lookup_map in pairs(index.lookup_maps) do
-        local old_key = old_consumer and old_consumer.auth_conf[key_attr]
-        local new_key = new_consumer and new_consumer.auth_conf[key_attr]
+        local old_key = old_consumer and get_filled_consumer(old_consumer).auth_conf[key_attr]
+        local new_key = new_consumer and get_filled_consumer(new_consumer).auth_conf[key_attr]
 
         if old_key and old_key ~= new_key then
             remove_lookup_member(lookup_map, old_key, etcd_key)
@@ -418,7 +418,25 @@ local function remove_index_consumer(index, etcd_key)
         index.pos_by_etcd_key[last_consumer._etcd_key] = pos
     end
 
-    return sync_lookup_maps(index, old_consumer, nil)
+    local ok, err = sync_lookup_maps(index, old_consumer, nil)
+    if not ok then
+        return nil, err
+    end
+
+    if last_consumer and last_consumer._etcd_key ~= etcd_key then
+        local filled_consumer = get_filled_consumer(last_consumer)
+        for key_attr, lookup_map in pairs(index.lookup_maps) do
+            local auth_key = filled_consumer.auth_conf[key_attr]
+            if auth_key ~= nil then
+                local refreshed, refresh_err = refresh_lookup_winner(index, lookup_map, auth_key)
+                if not refreshed then
+                    return nil, refresh_err
+                end
+            end
+        end
+    end
+
+    return true
 end
 
 
@@ -429,10 +447,11 @@ local function create_incremental_consume_cache(index, key_attr)
     }
 
     for _, consumer in ipairs(index.nodes) do
-        local auth_key = consumer.auth_conf[key_attr]
+        local filled_consumer = get_filled_consumer(consumer)
+        local auth_key = filled_consumer.auth_conf[key_attr]
         if auth_key ~= nil then
             add_lookup_member(lookup_map, auth_key, consumer._etcd_key)
-            lookup_map.values[auth_key] = get_filled_consumer(consumer)
+            lookup_map.values[auth_key] = filled_consumer
         end
     end
 
@@ -531,7 +550,8 @@ local function apply_incremental_plugin_index(index, plugin_name)
         keys_to_process[short_key] = true
 
         if is_consumer_short_key(short_key) then
-            local credential_keys = credential_keys_by_consumer[get_consumer_name_from_short_key(short_key)]
+            local consumer_name = get_consumer_name_from_short_key(short_key)
+            local credential_keys = credential_keys_by_consumer[consumer_name]
             if credential_keys then
                 for credential_key in pairs(credential_keys) do
                     keys_to_process[credential_key] = true

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -23,8 +23,10 @@ local check_schema   = require("apisix.core.schema").check
 local error          = error
 local ipairs         = ipairs
 local pairs          = pairs
+local next           = next
 local type           = type
 local string_sub     = string.sub
+local string_find    = string.find
 local consumers
 
 
@@ -40,6 +42,10 @@ local lrucache = core.lrucache.new({
 -- variable based on the number of consumers in the current environment,
 -- taking into account the appropriate adjustment coefficient.
 local consumers_count_for_lrucache = 4096
+local incremental_consumer_index_enabled = false
+local plugin_indexes = {}
+local credential_keys_by_consumer = {}
+local credential_keys_full_sync_version = 0
 
 local function remove_etcd_prefix(key)
     local prefix = ""
@@ -73,6 +79,28 @@ local function get_credential_id_from_etcd_key(key)
     return uri_segs[5]
 end
 
+local function get_consumer_short_key(key)
+    local short_key = remove_etcd_prefix(key)
+    return string_sub(short_key, #"/consumers/" + 1)
+end
+
+local function is_consumer_short_key(key)
+    return key and not string_find(key, "/credentials/", 1, true)
+end
+
+local function get_consumer_name_from_short_key(key)
+    if not key then
+        return nil
+    end
+
+    local pos = string_find(key, "/credentials/", 1, true)
+    if not pos then
+        return key
+    end
+
+    return string_sub(key, 1, pos - 1)
+end
+
 local function filter_consumers_list(data_list)
     if #data_list == 0 then
         return data_list
@@ -89,12 +117,18 @@ local function filter_consumers_list(data_list)
 end
 
 local plugin_consumer
+local construct_consumer_data
+local get_filled_consumer
+local create_consume_cache
 do
     local consumers_id_lrucache = core.lrucache.new({
             count = consumers_count_for_lrucache
         })
+    local consumer_lrucache = core.lrucache.new({
+            count = consumers_count_for_lrucache
+        })
 
-local function construct_consumer_data(val, name, plugin_config)
+function construct_consumer_data(val, name, plugin_config)
     -- if the val is a Consumer, clone it to the local consumer;
     -- if the val is a Credential, to get the Consumer by consumer_name and then clone
     -- it to the local consumer.
@@ -103,7 +137,7 @@ local function construct_consumer_data(val, name, plugin_config)
         local consumer_name = get_consumer_name_from_credential_etcd_key(val.key)
         local the_consumer = consumers:get(consumer_name)
         if the_consumer and the_consumer.value then
-            consumer = consumers_id_lrucache(val.value.id .. name, val.modifiedIndex..
+            consumer = consumers_id_lrucache(val.value.id .. name, val.modifiedIndex ..
                                                 the_consumer.modifiedIndex,
                 function (val, the_consumer)
                     consumer = core.table.clone(the_consumer.value)
@@ -112,11 +146,7 @@ local function construct_consumer_data(val, name, plugin_config)
                     return consumer
                 end, val, the_consumer)
         else
-            -- Normally wouldn't get here:
-            -- it should belong to a consumer for any credential.
-            return nil, "failed to get the consumer for the credential,",
-                " a wild credential has appeared!",
-                " credential key: ", val.key, ", consumer name: ", consumer_name
+            return nil, "failed to get the consumer for the credential, key: " .. val.key
         end
     else
         consumer = consumers_id_lrucache(val.value.id .. name, val.modifiedIndex,
@@ -127,18 +157,27 @@ local function construct_consumer_data(val, name, plugin_config)
             end, val)
     end
 
-    -- if the consumer has labels, set the field custom_id to it.
-    -- the custom_id is used to set in the request headers to the upstream.
     if consumer.labels then
         consumer.custom_id = consumer.labels["custom_id"]
     end
 
-    -- Note: the id here is the key of consumer data, which
-    -- is 'username' field in admin
     consumer.consumer_name = consumer.id
+    consumer._etcd_key = get_consumer_short_key(val.key)
     consumer.auth_conf = plugin_config
 
     return consumer
+end
+
+
+local function fill_consumer_secret(consumer)
+    local new_consumer = core.table.clone(consumer)
+    new_consumer.auth_conf = secret.fetch_secrets(new_consumer.auth_conf, false)
+    return new_consumer
+end
+
+
+function get_filled_consumer(consumer)
+    return consumer_lrucache(consumer, nil, fill_consumer_secret, consumer)
 end
 
 
@@ -149,9 +188,6 @@ function plugin_consumer()
         return plugins
     end
 
-    -- consumers.values is the list that got from etcd by prefix key {etcd_prefix}/consumers.
-    -- So it contains consumers and credentials.
-    -- The val in the for-loop may be a Consumer or a Credential.
     for _, val in ipairs(consumers.values) do
         if type(val) ~= "table" then
             goto CONTINUE
@@ -176,8 +212,7 @@ function plugin_consumer()
                 end
 
                 plugins[name].len = plugins[name].len + 1
-                core.table.insert(plugins[name].nodes, plugins[name].len,
-                                    consumer)
+                core.table.insert(plugins[name].nodes, plugins[name].len, consumer)
             end
         end
 
@@ -187,6 +222,338 @@ function plugin_consumer()
     return plugins
 end
 
+
+function create_consume_cache(consumers_conf, key_attr)
+    local consumer_names = {}
+
+    for _, consumer in ipairs(consumers_conf.nodes) do
+        local new_consumer = get_filled_consumer(consumer)
+        consumer_names[new_consumer.auth_conf[key_attr]] = new_consumer
+    end
+
+    return consumer_names
+end
+
+end
+
+
+local function new_plugin_index(plugin_name)
+    return {
+        plugin_name = plugin_name,
+        conf_version = 0,
+        full_sync_version = 0,
+        built = false,
+        invalid = false,
+        dirty_keys = {},
+        nodes = {},
+        len = 0,
+        pos_by_etcd_key = {},
+        by_etcd_key = {},
+        lookup_maps = {},
+    }
+end
+
+
+local function clear_plugin_index(index)
+    index.conf_version = 0
+    index.full_sync_version = 0
+    index.built = false
+    index.invalid = false
+    index.dirty_keys = {}
+    index.nodes = {}
+    index.len = 0
+    index.pos_by_etcd_key = {}
+    index.by_etcd_key = {}
+    index.lookup_maps = {}
+end
+
+
+local function add_lookup_member(lookup_map, auth_key, etcd_key)
+    if auth_key == nil or not etcd_key then
+        return
+    end
+
+    local members = lookup_map.members[auth_key]
+    if not members then
+        members = {}
+        lookup_map.members[auth_key] = members
+    end
+
+    members[etcd_key] = true
+end
+
+
+local function remove_lookup_member(lookup_map, auth_key, etcd_key)
+    if auth_key == nil or not etcd_key then
+        return
+    end
+
+    local members = lookup_map.members[auth_key]
+    if not members then
+        return
+    end
+
+    members[etcd_key] = nil
+    if next(members) == nil then
+        lookup_map.members[auth_key] = nil
+    end
+end
+
+
+local function refresh_lookup_winner(index, lookup_map, auth_key)
+    if auth_key == nil then
+        return true
+    end
+
+    local members = lookup_map.members[auth_key]
+    if not members then
+        lookup_map.values[auth_key] = nil
+        return true
+    end
+
+    local winner
+    local winner_pos = 0
+    for etcd_key in pairs(members) do
+        local consumer = index.by_etcd_key[etcd_key]
+        local pos = index.pos_by_etcd_key[etcd_key]
+        if not consumer or not pos then
+            return nil, "failed to locate consumer by etcd key: " .. tostring(etcd_key)
+        end
+
+        if pos >= winner_pos then
+            winner = consumer
+            winner_pos = pos
+        end
+    end
+
+    if not winner then
+        lookup_map.members[auth_key] = nil
+        lookup_map.values[auth_key] = nil
+        return true
+    end
+
+    lookup_map.values[auth_key] = get_filled_consumer(winner)
+    return true
+end
+
+
+local function sync_lookup_maps(index, old_consumer, new_consumer)
+    local etcd_key = old_consumer and old_consumer._etcd_key or new_consumer._etcd_key
+
+    for key_attr, lookup_map in pairs(index.lookup_maps) do
+        local old_key = old_consumer and old_consumer.auth_conf[key_attr]
+        local new_key = new_consumer and new_consumer.auth_conf[key_attr]
+
+        if old_key and old_key ~= new_key then
+            remove_lookup_member(lookup_map, old_key, etcd_key)
+        end
+        if new_key then
+            add_lookup_member(lookup_map, new_key, etcd_key)
+        end
+
+        if old_key == new_key then
+            local ok, err = refresh_lookup_winner(index, lookup_map, old_key)
+            if not ok then
+                return nil, err
+            end
+        else
+            if old_key then
+                local ok, err = refresh_lookup_winner(index, lookup_map, old_key)
+                if not ok then
+                    return nil, err
+                end
+            end
+            if new_key then
+                local ok, err = refresh_lookup_winner(index, lookup_map, new_key)
+                if not ok then
+                    return nil, err
+                end
+            end
+        end
+    end
+
+    return true
+end
+
+
+local function upsert_index_consumer(index, consumer)
+    local etcd_key = consumer._etcd_key
+    local pos = index.pos_by_etcd_key[etcd_key]
+    if pos then
+        local old_consumer = index.nodes[pos]
+        if not old_consumer then
+            return nil, "failed to locate existing consumer at position: " .. pos
+        end
+
+        index.nodes[pos] = consumer
+        index.by_etcd_key[etcd_key] = consumer
+        return sync_lookup_maps(index, old_consumer, consumer)
+    end
+
+    index.len = index.len + 1
+    pos = index.len
+    index.nodes[pos] = consumer
+    index.pos_by_etcd_key[etcd_key] = pos
+    index.by_etcd_key[etcd_key] = consumer
+
+    return sync_lookup_maps(index, nil, consumer)
+end
+
+
+local function remove_index_consumer(index, etcd_key)
+    local pos = index.pos_by_etcd_key[etcd_key]
+    if not pos then
+        return true
+    end
+
+    local old_consumer = index.nodes[pos]
+    local last_consumer = index.nodes[index.len]
+    index.nodes[pos] = last_consumer
+    index.nodes[index.len] = nil
+    index.len = index.len - 1
+    index.pos_by_etcd_key[etcd_key] = nil
+    index.by_etcd_key[etcd_key] = nil
+
+    if last_consumer and last_consumer._etcd_key ~= etcd_key then
+        index.pos_by_etcd_key[last_consumer._etcd_key] = pos
+    end
+
+    return sync_lookup_maps(index, old_consumer, nil)
+end
+
+
+local function create_incremental_consume_cache(index, key_attr)
+    local lookup_map = {
+        values = {},
+        members = {},
+    }
+
+    for _, consumer in ipairs(index.nodes) do
+        local auth_key = consumer.auth_conf[key_attr]
+        if auth_key ~= nil then
+            add_lookup_member(lookup_map, auth_key, consumer._etcd_key)
+            lookup_map.values[auth_key] = get_filled_consumer(consumer)
+        end
+    end
+
+    return lookup_map
+end
+
+
+local function rebuild_credential_keys_by_consumer()
+    credential_keys_by_consumer = {}
+
+    if not consumers or not consumers.values then
+        credential_keys_full_sync_version = consumers and consumers.full_sync_version or 0
+        return
+    end
+
+    for _, val in ipairs(consumers.values) do
+        if type(val) == "table" and is_credential_etcd_key(val.key) then
+            local consumer_name = get_consumer_name_from_credential_etcd_key(val.key)
+            local credential_keys = credential_keys_by_consumer[consumer_name]
+            if not credential_keys then
+                credential_keys = {}
+                credential_keys_by_consumer[consumer_name] = credential_keys
+            end
+
+            credential_keys[get_consumer_short_key(val.key)] = true
+        end
+    end
+
+    credential_keys_full_sync_version = consumers.full_sync_version or 0
+end
+
+
+local function build_incremental_plugin_index(plugin_name, index)
+    clear_plugin_index(index)
+
+    if consumers.values then
+        for _, val in ipairs(consumers.values) do
+            if type(val) == "table" then
+                local plugin_conf = val.value.plugins and val.value.plugins[plugin_name]
+                if plugin_conf then
+                    local consumer, err = construct_consumer_data(val, plugin_name, plugin_conf)
+                    if consumer then
+                        local ok, sync_err = upsert_index_consumer(index, consumer)
+                        if not ok then
+                            return nil, sync_err
+                        end
+                    else
+                        core.log.error("failed to construct consumer data for plugin ",
+                                       plugin_name, ": ", err)
+                    end
+                end
+            end
+        end
+    end
+
+    index.built = true
+    index.conf_version = consumers.conf_version
+    index.full_sync_version = consumers.full_sync_version or 0
+    index.invalid = false
+    index.dirty_keys = {}
+
+    return index
+end
+
+
+local function reconcile_index_consumer(index, plugin_name, short_key)
+    local val = consumers:get(short_key)
+    local plugin_conf = val and val.value and val.value.plugins and val.value.plugins[plugin_name]
+    if not plugin_conf then
+        return remove_index_consumer(index, short_key)
+    end
+
+    local consumer, err = construct_consumer_data(val, plugin_name, plugin_conf)
+    if not consumer then
+        if is_credential_etcd_key(val.key) then
+            return remove_index_consumer(index, short_key)
+        end
+
+        return nil, err
+    end
+
+    return upsert_index_consumer(index, consumer)
+end
+
+
+local function apply_incremental_plugin_index(index, plugin_name)
+    local dirty_keys = index.dirty_keys
+    if next(dirty_keys) == nil then
+        index.conf_version = consumers.conf_version
+        index.full_sync_version = consumers.full_sync_version or 0
+        return index
+    end
+
+    local keys_to_process = {}
+    for short_key in pairs(dirty_keys) do
+        keys_to_process[short_key] = true
+
+        if is_consumer_short_key(short_key) then
+            local credential_keys = credential_keys_by_consumer[get_consumer_name_from_short_key(short_key)]
+            if credential_keys then
+                for credential_key in pairs(credential_keys) do
+                    keys_to_process[credential_key] = true
+                end
+            end
+        end
+    end
+
+    index.dirty_keys = {}
+
+    for short_key in pairs(keys_to_process) do
+        local ok, err = reconcile_index_consumer(index, plugin_name, short_key)
+        if not ok then
+            index.invalid = true
+            return nil, err
+        end
+    end
+
+    index.conf_version = consumers.conf_version
+    index.full_sync_version = consumers.full_sync_version or 0
+
+    return index
 end
 
 
@@ -197,11 +564,55 @@ function _M.get_consumer_key_from_credential_key(key)
     return "/consumers/" .. uri_segs[3]
 end
 
+
 function _M.plugin(plugin_name)
+    if incremental_consumer_index_enabled then
+        local plugin_obj = plugin.get(plugin_name)
+        if not plugin_obj or plugin_obj.type ~= "auth" then
+            return nil
+        end
+
+        if credential_keys_full_sync_version ~= (consumers.full_sync_version or 0) then
+            rebuild_credential_keys_by_consumer()
+        end
+
+        local index = plugin_indexes[plugin_name]
+        if not index then
+            index = new_plugin_index(plugin_name)
+            plugin_indexes[plugin_name] = index
+        end
+
+        if not index.built or index.invalid or
+           index.full_sync_version ~= (consumers.full_sync_version or 0) then
+            local _, err = build_incremental_plugin_index(plugin_name, index)
+            if err then
+                core.log.error("failed to build consumer index for plugin ",
+                               plugin_name, ": ", err)
+                return nil
+            end
+        elseif index.conf_version ~= consumers.conf_version then
+            local _, err = apply_incremental_plugin_index(index, plugin_name)
+            if err then
+                core.log.error("failed to apply consumer index for plugin ",
+                               plugin_name, ": ", err)
+
+                local _, rebuild_err = build_incremental_plugin_index(plugin_name, index)
+                if rebuild_err then
+                    core.log.error("failed to rebuild consumer index for plugin ",
+                                   plugin_name, ": ", rebuild_err)
+                    return nil
+                end
+            end
+        end
+
+        return index
+    end
+
     local plugin_conf = core.lrucache.global("/consumers",
                             consumers.conf_version, plugin_consumer)
     return plugin_conf[plugin_name]
 end
+
 
 function _M.consumers_conf(plugin_name)
     return _M.plugin(plugin_name)
@@ -230,35 +641,17 @@ function _M.consumers()
 end
 
 
-local create_consume_cache
-do
-    local consumer_lrucache = core.lrucache.new({
-            count = consumers_count_for_lrucache
-        })
+function _M.consumers_kv(plugin_name, consumer_conf, key_attr)
+    if incremental_consumer_index_enabled and consumer_conf then
+        local lookup_map = consumer_conf.lookup_maps[key_attr]
+        if not lookup_map then
+            lookup_map = create_incremental_consume_cache(consumer_conf, key_attr)
+            consumer_conf.lookup_maps[key_attr] = lookup_map
+        end
 
-local function fill_consumer_secret(consumer)
-    local new_consumer = core.table.clone(consumer)
-    new_consumer.auth_conf = secret.fetch_secrets(new_consumer.auth_conf, false)
-    return new_consumer
-end
-
-
-function create_consume_cache(consumers_conf, key_attr)
-    local consumer_names = {}
-
-    for _, consumer in ipairs(consumers_conf.nodes) do
-        local new_consumer = consumer_lrucache(consumer, nil,
-                                fill_consumer_secret, consumer)
-        consumer_names[new_consumer.auth_conf[key_attr]] = new_consumer
+        return lookup_map.values
     end
 
-    return consumer_names
-end
-
-end
-
-
-function _M.consumers_kv(plugin_name, consumer_conf, key_attr)
     local consumers = lrucache("consumers_key#" .. plugin_name, consumer_conf.conf_version,
         create_consume_cache, consumer_conf, key_attr)
 
@@ -296,15 +689,53 @@ end
 
 
 local function filter(consumer)
-    if not consumer.value or not consumer.value.plugins then
+    if consumer.value and consumer.value.plugins then
+        plugin.set_plugins_meta_parent(consumer.value.plugins, consumer)
+    end
+
+    if not incremental_consumer_index_enabled or not consumer.key then
         return
     end
-    plugin.set_plugins_meta_parent(consumer.value.plugins, consumer)
+
+    local short_key = get_consumer_short_key(consumer.key)
+    if not short_key then
+        return
+    end
+
+    if is_credential_etcd_key(consumer.key) then
+        local consumer_name = get_consumer_name_from_credential_etcd_key(consumer.key)
+        local credential_keys = credential_keys_by_consumer[consumer_name]
+
+        if consumer.value then
+            if not credential_keys then
+                credential_keys = {}
+                credential_keys_by_consumer[consumer_name] = credential_keys
+            end
+
+            credential_keys[short_key] = true
+        elseif credential_keys then
+            credential_keys[short_key] = nil
+            if next(credential_keys) == nil then
+                credential_keys_by_consumer[consumer_name] = nil
+            end
+        end
+    end
+
+    for _, index in pairs(plugin_indexes) do
+        index.dirty_keys[short_key] = true
+    end
 end
 
 
 function _M.init_worker()
     local err
+    local local_conf = config_local.local_conf()
+    incremental_consumer_index_enabled =
+        core.table.try_read_attr(local_conf, "apisix", "enable_incremental_consumer_index") or false
+    plugin_indexes = {}
+    credential_keys_by_consumer = {}
+    credential_keys_full_sync_version = 0
+
     local cfg = {
         automatic = true,
         checker = check_consumer,
@@ -326,7 +757,6 @@ local function get_anonymous_consumer_from_local_cache(name)
         return nil, nil, "failed to get anonymous consumer " .. name
     end
 
-    -- make structure of anon_consumer similar to that of consumer_mod.consumers_kv's response
     local anon_consumer = anon_consumer_raw.value
     anon_consumer.consumer_name = anon_consumer_raw.value.id
     anon_consumer.modifiedIndex = anon_consumer_raw.modifiedIndex

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -640,6 +640,8 @@ local function load_full_data(self, dir_res, headers)
         self.conf_version = self.conf_version + 1
     end
 
+    self.full_sync_version = self.prev_index
+
     self.need_reload = false
     sync_status_to_shdict(true)
 end
@@ -1033,6 +1035,7 @@ function _M.new(key, opts)
         sync_times = 0,
         running = true,
         conf_version = 0,
+        full_sync_version = 0,
         values = {},
         need_reload = true,
         watching_stream = nil,

--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -219,6 +219,8 @@ local function sync_data(self)
         return true
     end
 
+    self.full_sync_version = conf_version
+
     local items = apisix_yaml[self.key]
     if not items then
         self.values = new_tab(8, 0)
@@ -494,6 +496,7 @@ function _M.new(key, opts)
         sync_times = 0,
         running = true,
         conf_version = 0,
+        full_sync_version = 0,
         values = nil,
         routes_hash = nil,
         prev_index = nil,

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -28,6 +28,7 @@ apisix:
   enable_admin: true           # Admin API
   enable_dev_mode: false       # If true, set nginx `worker_processes` to 1.
   enable_reuseport: true       # If true, enable nginx SO_REUSEPORT option.
+  enable_incremental_consumer_index: false  # If true, incrementally maintain auth consumer indexes instead of rebuilding them on every consumer change.
   show_upstream_status_in_response_header: false  # If true, include the upstream HTTP status code in
                                                   # the response header `X-APISIX-Upstream-Status`.
                                                   # If false, show `X-APISIX-Upstream-Status` only if

--- a/t/cli/test_etcd_sync_event_handle.sh
+++ b/t/cli/test_etcd_sync_event_handle.sh
@@ -19,6 +19,58 @@
 
 . ./t/cli/common.sh
 
+check_round_2_requests() {
+    local code
+
+    code="$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/1)" || return 1
+    if [ "$code" != "204" ]; then
+        return 1
+    fi
+
+    code="$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/2)" || return 1
+    if [ "$code" != "503" ]; then
+        return 1
+    fi
+
+    code="$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/3)" || return 1
+    if [ "$code" != "204" ]; then
+        return 1
+    fi
+
+    code="$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/4)" || return 1
+    if [ "$code" != "204" ]; then
+        return 1
+    fi
+
+    code="$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/5)" || return 1
+    if [ "$code" != "204" ]; then
+        return 1
+    fi
+
+    code="$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/6)" || return 1
+    if [ "$code" != "404" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+wait_for_round_2_sync() {
+    local i
+
+    for i in {1..20}; do
+        if check_round_2_requests \
+            && grep -q "etcd events sent in bulk" logs/error.log \
+            && grep -q "failed to check item data" logs/error.log; then
+            return 0
+        fi
+
+        sleep 1
+    done
+
+    return 1
+}
+
 # check etcd while enable auth
 git checkout conf/config.yaml
 
@@ -89,7 +141,11 @@ etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync put /apisix/rout
 etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync auth disable
 etcdctl --endpoints=127.0.0.1:2379 user delete root
 etcdctl --endpoints=127.0.0.1:2379 role delete root
-sleep 5 # wait resync by watch
+
+if ! wait_for_round_2_sync; then
+    echo "failed: timed out waiting for watch backlog to be applied"
+    exit 1
+fi
 
 # Test request
 # All but the intentionally incoming misconfigurations should be applied,

--- a/t/node/consumer-incremental-index.t
+++ b/t/node/consumer-incremental-index.t
@@ -1,0 +1,270 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+my $yaml_config = <<_EOC_;
+apisix:
+  enable_incremental_consumer_index: true
+_EOC_
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->yaml_config) {
+        $block->set_value("yaml_config", $yaml_config);
+    }
+
+    if (!$block->no_error_log && !$block->error_log) {
+        $block->set_value("no_error_log", "[error]\n[alert]");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: enable key-auth on the route /echo
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/echo"
+                }]]
+            )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: create consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack"
+                }]]
+            )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: create the first credential for the consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers/jack/credentials/cred-a',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {"key": "first-secret"}
+                    }
+                }]]
+            )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 4: create the second credential for the consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers/jack/credentials/cred-b',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {"key": "second-secret"}
+                    }
+                }]]
+            )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 5: both credentials can authenticate
+--- request
+GET /echo
+--- more_headers
+apikey: second-secret
+--- response_headers
+x-consumer-username: jack
+x-credential-identifier: cred-b
+
+
+
+=== TEST 6: deleting one credential does not affect the other
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code = t('/apisix/admin/consumers/jack/credentials/cred-a', ngx.HTTP_DELETE)
+
+            ngx.sleep(0.2)
+
+            local keep_code = t('/echo', ngx.HTTP_GET, "", nil, {apikey = "second-secret"})
+            local delete_code = t('/echo', ngx.HTTP_GET, "", nil, {apikey = "first-secret"})
+
+            ngx.say(code)
+            ngx.say(keep_code)
+            ngx.say(delete_code)
+        }
+    }
+--- request
+GET /t
+--- response_body
+200
+200
+401
+
+
+
+=== TEST 7: updating the top-level consumer updates derived credential metadata
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "labels": {
+                        "custom_id": "updated-id"
+                    }
+                }]]
+            )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 8: the surviving credential sees the updated custom_id
+--- request
+GET /echo
+--- more_headers
+apikey: second-secret
+--- response_headers
+x-consumer-username: jack
+x-credential-identifier: cred-b
+x-consumer-custom-id: updated-id
+
+
+
+=== TEST 9: consumers_kv returns the incrementally updated consumer view
+--- config
+    location /t {
+        content_by_lua_block {
+            local consumer_mod = require("apisix.consumer")
+
+            ngx.sleep(0.2)
+
+            local consumer_conf = consumer_mod.plugin("key-auth")
+            local consumers = consumer_mod.consumers_kv("key-auth", consumer_conf, "key")
+            local consumer = consumers["second-secret"]
+
+            ngx.say(consumer.consumer_name)
+            ngx.say(consumer.custom_id)
+            ngx.say(consumer.credential_id)
+        }
+    }
+--- request
+GET /t
+--- response_body
+jack
+updated-id
+cred-b
+
+
+
+=== TEST 10: deleting the top-level consumer invalidates the derived credential
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code = t('/apisix/admin/consumers/jack', ngx.HTTP_DELETE)
+
+            ngx.sleep(0.2)
+
+            local request_code = t('/echo', ngx.HTTP_GET, "", nil, {apikey = "second-secret"})
+
+            ngx.say(code)
+            ngx.say(request_code)
+        }
+    }
+--- request
+GET /t
+--- response_body
+200
+401

--- a/t/node/consumer-incremental-index.t
+++ b/t/node/consumer-incremental-index.t
@@ -69,6 +69,7 @@ __DATA__
     }
 --- request
 GET /t
+--- error_code: 201
 --- response_body
 passed
 
@@ -92,6 +93,7 @@ passed
     }
 --- request
 GET /t
+--- error_code: 201
 --- response_body
 passed
 
@@ -117,6 +119,7 @@ passed
     }
 --- request
 GET /t
+--- error_code: 201
 --- response_body
 passed
 
@@ -142,6 +145,7 @@ passed
     }
 --- request
 GET /t
+--- error_code: 201
 --- response_body
 passed
 


### PR DESCRIPTION
## 问题描述

当前 `consumer` / `credential` 发生变更后，认证相关请求会在 worker 的请求路径上触发 `consumer` 索引重建。

在 `consumer` 数量较多，或者控制面频繁写入 `consumer` / `credential` 的场景下，这会带来两个直接问题：

- 认证请求延迟会随着 `consumer` 总量增长而明显抖动。
- 不相关流量也会被 worker 上的重建开销拖慢，出现额外 CPU 峰值。

## 问题原因

根因不在 `etcd watcher` 本身。

`/consumers` 的 watcher 已经是增量同步，但 `apisix/consumer.lua` 仍然在请求路径上做了两次全量扫描：

1. `_M.plugin(plugin_name)` 通过 `lrucache.global("/consumers", conf_version, plugin_consumer)`，在 `conf_version` 变化后重新全量扫描 `consumers.values`，重建每个 auth plugin 的 `nodes`。
2. `_M.consumers_kv(plugin_name, consumer_conf, key_attr)` 又会基于新的 `nodes` 再扫描一次，重新构造 `key -> consumer` 查找表。

这两个步骤都是 `O(N)`，并且每个 worker 都会各自执行一次，所以在大量 `consumer` 或高频变更场景下，开销会被直接放大到代理热路径。

## 解决办法

本 PR 为 `consumer` 认证索引增加了一条可开关的增量维护路径，默认关闭，不改变现有默认行为。

### 1. 引入开关

新增配置项：

```yaml
apisix:
  enable_incremental_consumer_index: false
```

开启后使用增量索引路径；关闭时继续走原有全量重建逻辑。

### 2. 将 watcher 回调改为只标记 dirty key

`/consumers` 的 filter 回调不再尝试重建索引，而是只负责：

- 提取变更的 `short key`
- 维护 `consumer -> credential keys` 的关联关系
- 将 dirty key 标记到已经创建过的 auth plugin 索引上

这样 watcher 仍然保持轻量，不把重建成本提前放到同步阶段。

### 3. 为每个 auth plugin 维护增量索引

在 `apisix/consumer.lua` 中引入按 plugin 维度维护的索引结构，包含：

- `nodes`
- `pos_by_etcd_key`
- `by_etcd_key`
- `lookup_maps`
- `dirty_keys`
- `conf_version`
- `full_sync_version`

行为上：

- 首次访问某个 auth plugin 时，做一次 full build。
- 后续当 `consumers.conf_version` 变化时，只对 dirty keys 做增量 reconcile。
- 删除场景使用稠密数组的 `swap-remove`，避免 tombstone 和再次 compact。

### 4. 增量维护 `consumers_kv()` 的查找表

不仅优化 `plugin_consumer()`，同时也把 `consumers_kv()` 改成基于索引的增量维护。

这样可以避免第一次鉴权命中时，因为 `conf_version` 变化又额外触发一次 `nodes` 全量扫描。

### 5. 在 full reload 后自动回退到安全的 full rebuild

为配置对象补充 `full_sync_version`。

当 `etcd` / YAML 配置进入全量快照重载路径时，增量索引会识别这是一次 full sync，并在下次访问该 plugin 时自动执行一次 full rebuild，避免旧索引与新快照混用。

### 6. 保留回退能力

如果增量 apply 过程中检测到内部不一致，会将索引标记为 `invalid`，下一次访问自动退回 full rebuild，保证一致性优先。

## 验证

新增了启用开关后的回归测试，覆盖：

- credential 新增 / 删除后鉴权立即生效
- 顶层 consumer 元数据更新后，credential 派生 consumer 视图同步更新
- 顶层 consumer 删除后，对应 credential 派生项立即失效
- `consumers_kv()` 读取到的视图与增量索引保持一致

本地已完成 `git diff --check`。

完整 APISIX Perl 测试未能在当前环境直接执行，原因是本机缺少 `Test::Nginx::Socket::Lua::Stream` 依赖；GitHub Actions 已通过 PR 触发进行验证。
